### PR TITLE
Hot fix: Export file name error when the file name contains `.`.

### DIFF
--- a/src/ViewModels/ChampionshipResultConvertViewModel.cs
+++ b/src/ViewModels/ChampionshipResultConvertViewModel.cs
@@ -79,8 +79,8 @@ public class ChampionshipResultConvertViewModel : INotifyPropertyChanged
         var zonResults = ZRoundRaceResultItems.Where(result => result is { IsCheck: true, ParseResult.IsValid: true })
                                               .Select(result => converter.ConvertToTarget(result.ParseResult.ZRoundResult));
 
-        var convertResult = zonResults.Aggregate(true, 
-            (current, zonResult) => current & JsonUtil.SaveAsJson(zonResult, Path.ChangeExtension(Path.Combine(ChampionshipFolderPath, zonResult.Name), "json")));
+        var convertResult = zonResults.Aggregate(true,
+            (current, zonResult) => current & JsonUtil.SaveAsJson(zonResult, Path.Combine(ChampionshipFolderPath, zonResult.Name) + ".json"));
 
         _setConvertResult(convertResult, convertResult ? Resource.ConvertResult_Succeed : Resource.ConvertResult_Failed);
     }


### PR DESCRIPTION
This is a hot fix. Mr. DuoRo found that the racing results of the Dalian Touring Car Series cannot be exported. After investigating, it was found that the result name contains a dot (.) and the following text was replaced as the extension of the file name.